### PR TITLE
/search 키워드 검색, 정렬 api 구현

### DIFF
--- a/src/main/java/com/hsu/mamomo/controller/CampaignSearchController.java
+++ b/src/main/java/com/hsu/mamomo/controller/CampaignSearchController.java
@@ -1,0 +1,29 @@
+package com.hsu.mamomo.controller;
+
+import com.hsu.mamomo.domain.Campaign;
+import com.hsu.mamomo.repository.CampaignSearchRepository;
+import com.hsu.mamomo.service.CampaignSearchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@RestController
+public class CampaignSearchController {
+
+    private final CampaignSearchService campaignSearchService;
+    private final CampaignSearchRepository campaignSearchRepository;
+
+    @GetMapping("/search")
+    public List<Campaign> searchByTitleOrBody(@RequestParam(value = "keyword") String keyword,
+                                              @RequestParam(value = "sort", defaultValue = "start_date,desc") String sort) {
+        String[] _sort = sort.split(",");
+        // sort = [field, direction]
+        return campaignSearchService.searchByTitleOrBody(keyword, _sort[0], _sort[1]);
+    }
+}

--- a/src/main/java/com/hsu/mamomo/domain/Campaign.java
+++ b/src/main/java/com/hsu/mamomo/domain/Campaign.java
@@ -10,6 +10,8 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 import org.springframework.lang.Nullable;
 
 import javax.persistence.*;
+import java.time.LocalDate;
+import java.util.Date;
 import java.util.List;
 
 @Getter
@@ -29,14 +31,14 @@ public class Campaign {
     @Field(name = "url", type = FieldType.Keyword)
     private String url;
 
-    @Field(name = "title", type = FieldType.Keyword)
+    @Field(name = "title", type = FieldType.Text)
     private String title;
 
     @ElementCollection
-    @Field(name = "tags", type = FieldType.Keyword)
+    @Field(name = "tags")
     private List<String> tags;
 
-    @Field(name = "body", type = FieldType.Keyword)
+    @Field(name = "body", type = FieldType.Text)
     private String body;
 
     @Field(name = "organization_name", type = FieldType.Keyword)
@@ -46,19 +48,19 @@ public class Campaign {
     private String thumbnail;
 
     // 편의상 String으로 설정
-    @Field(name = "due_date", type = FieldType.Keyword)
-    private String dueDate;
+    @Field(name = "due_date", type = FieldType.Date)
+    private LocalDate dueDate;
 
-    @Field(name = "start_date", type = FieldType.Keyword)
-    private String startDate;
+    @Field(name = "start_date", type = FieldType.Date)
+    private LocalDate startDate;
 
-    @Field(name = "target_price", type = FieldType.Keyword)
-    private String targetPrice;
+    @Field(name = "target_price", type = FieldType.Long)
+    private Long targetPrice;
 
-    @Field(name = "status_price", type = FieldType.Keyword)
-    private String statusPrice;
+    @Field(name = "status_price", type = FieldType.Long)
+    private Long statusPrice;
 
-    @Field(name = "percent", type = FieldType.Keyword)
-    private String percent;
+    @Field(name = "percent", type = FieldType.Integer)
+    private Integer percent;
 
 }

--- a/src/main/java/com/hsu/mamomo/elastic/ElasticsearchConfig.java
+++ b/src/main/java/com/hsu/mamomo/elastic/ElasticsearchConfig.java
@@ -30,8 +30,8 @@ public class ElasticsearchConfig extends AbstractElasticsearchConfiguration {
     public RestHighLevelClient elasticsearchClient() {
 
         final ClientConfiguration clientConfiguration = ClientConfiguration.builder()
-                .connectedTo(host + ":" + port)
-                .withBasicAuth(username, password)
+                .connectedTo("localhost:9200")
+                //.withBasicAuth(username, password)
                 .build();
 
         return RestClients.create(clientConfiguration).rest();

--- a/src/main/java/com/hsu/mamomo/elastic/ElasticsearchOperation.java
+++ b/src/main/java/com/hsu/mamomo/elastic/ElasticsearchOperation.java
@@ -1,7 +1,0 @@
-package com.hsu.mamomo.elastic;
-
-import org.springframework.data.elasticsearch.core.DocumentOperations;
-import org.springframework.data.elasticsearch.core.SearchOperations;
-
-public interface ElasticsearchOperation extends DocumentOperations, SearchOperations {
-}

--- a/src/main/java/com/hsu/mamomo/repository/CampaignSearchRepository.java
+++ b/src/main/java/com/hsu/mamomo/repository/CampaignSearchRepository.java
@@ -1,0 +1,11 @@
+package com.hsu.mamomo.repository;
+
+import com.hsu.mamomo.domain.Campaign;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CampaignSearchRepository extends ElasticsearchRepository<Campaign, String> {
+
+
+}

--- a/src/main/java/com/hsu/mamomo/service/CampaignSearchService.java
+++ b/src/main/java/com/hsu/mamomo/service/CampaignSearchService.java
@@ -1,0 +1,58 @@
+package com.hsu.mamomo.service;
+
+import com.hsu.mamomo.domain.Campaign;
+import com.hsu.mamomo.repository.CampaignSearchRepository;
+import lombok.RequiredArgsConstructor;
+import org.elasticsearch.index.query.MultiMatchQueryBuilder;
+import org.elasticsearch.index.query.Operator;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.sort.FieldSortBuilder;
+import org.elasticsearch.search.sort.SortBuilders;
+import org.elasticsearch.search.sort.SortOrder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.mapping.IndexCoordinates;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class CampaignSearchService {
+    @Autowired
+    private ElasticsearchOperations elasticsearchOperations;
+    private final CampaignSearchRepository campaignSearchRepository;
+    private static final Map<String, SortOrder> sortMap = createSortMap();
+    private static Map<String, SortOrder> createSortMap() {
+        return Map.of("asc", SortOrder.ASC, "desc", SortOrder.DESC);
+    }
+
+    /*
+    * 제목 + 본문 검색 (OR)
+    * */
+    public List<Campaign> searchByTitleOrBody(String keyword, String item, String direction) {
+
+
+        MultiMatchQueryBuilder multiMatchQueryBuilder = QueryBuilders.multiMatchQuery(keyword,"title", "body")
+                .operator(Operator.AND);
+
+        FieldSortBuilder sortBuilder = SortBuilders.fieldSort(item).order(sortMap.get(direction));
+
+        NativeSearchQuery searchQuery = new NativeSearchQueryBuilder()
+                .withQuery(multiMatchQueryBuilder)
+                .withSorts(sortBuilder)
+                .build();
+
+        SearchHits<Campaign> searchHit = elasticsearchOperations.search(searchQuery, Campaign.class, IndexCoordinates.of("campaigns"));
+        System.out.println(searchHit);
+        return searchHit.stream()
+                .map(SearchHit::getContent)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,3 +7,4 @@ elasticsearch:
   port: 9200
   username: elastic
   password: hansung
+  connectTimeout: 6000


### PR DESCRIPTION
## Request url
```
/search?keyword={keyword}&sort={item},{direction}
```
- keyword : 검색어
- item : 정렬 기준 아이템 (es field name 기준)
  - 프론트에 elasticsearch field들 공유할 필요 O
- direction : asc, desc

 ## 구현 관련
- '.' 로 split해서 CampaignSearchController ->CampaignSearchService
- `ElasticsearchOperations` , `NativeSearchQuery` 사용
- HashMap에 SortOrder 매핑하여 정렬함
```java
private static Map<String, SortOrder> createSortMap() {
        return Map.of("asc", SortOrder.ASC, "desc", SortOrder.DESC);
    }
```

## 의문점들
- repository 안거치고 이렇게 하는게 맞는가?
- 구조에 대한 고민. 공부 하고 꼭 개선할것