### PR TITLE
:sparkles: 상위 태그 반환 api 구현 (#14)

### DIFF
--- a/src/main/java/com/hsu/mamomo/controller/CampaignSearchController.java
+++ b/src/main/java/com/hsu/mamomo/controller/CampaignSearchController.java
@@ -26,4 +26,9 @@ public class CampaignSearchController {
         // sort = [field, direction]
         return campaignSearchService.searchByTitleOrBody(keyword, _sort[0], _sort[1]);
     }
+
+    @GetMapping("/tag")
+    public List<String> searchTag() {
+        return campaignSearchService.findTag();
+    }
 }


### PR DESCRIPTION
- [페이지](https://github.com/eugenp/tutorials/blob/master/persistence-modules/spring-data-elasticsearch/src/test/java/com/baeldung/spring/data/es/ElasticSearchQueryManualTest.java) 의 `givenAnalyzedQuery_whenMakeAggregationOnTermCount_thenEachTokenCountsSeparately()` 함수 참고함

```
@Test
    public void givenAnalyzedQuery_whenMakeAggregationOnTermCount_thenEachTokenCountsSeparately() throws Exception {
        final TermsAggregationBuilder aggregation = AggregationBuilders.terms("top_tags")
            .field("title");

        final SearchSourceBuilder builder = new SearchSourceBuilder().aggregation(aggregation);
        final SearchRequest searchRequest = new SearchRequest("blog").source(builder);

        final SearchResponse response = client.search(searchRequest, RequestOptions.DEFAULT);

        final Map<String, Aggregation> results = response.getAggregations()
            .asMap();
        final ParsedStringTerms topTags = (ParsedStringTerms) results.get("top_tags");

        final List<String> keys = topTags.getBuckets()
            .stream()
            .map(MultiBucketsAggregation.Bucket::getKeyAsString)
            .sorted()
            .collect(toList());
        assertEquals(asList("about", "article", "data", "elasticsearch", "engines", "search", "second", "spring", "tutorial"), keys);
    }
```