### PR TITLE
:sparkles: 캠페인당 좋아요 갯수 추가 (#71)

### DIFF
--- a/BOOT-INF/classes/static/docs/api.html
+++ b/BOOT-INF/classes/static/docs/api.html
@@ -748,6 +748,11 @@ Host: localhost:8080</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 여부</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>campaigns.[].heartCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 갯수</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -766,7 +771,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 81787
+Content-Length: 82224
 
 {
   "campaigns" : [ {
@@ -784,7 +789,8 @@ Content-Length: 81787
     "targetPrice" : 2000000,
     "statusPrice" : 200,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94511",
     "siteType" : "kakao",
@@ -800,7 +806,8 @@ Content-Length: 81787
     "targetPrice" : 1168000,
     "statusPrice" : 251600,
     "percent" : 22,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94817",
     "siteType" : "kakao",
@@ -816,7 +823,8 @@ Content-Length: 81787
     "targetPrice" : 700000000,
     "statusPrice" : 555462400,
     "percent" : 80,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94598",
     "siteType" : "kakao",
@@ -832,7 +840,8 @@ Content-Length: 81787
     "targetPrice" : 10000000,
     "statusPrice" : 293400,
     "percent" : 3,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183433",
     "siteType" : "happybean",
@@ -848,7 +857,8 @@ Content-Length: 81787
     "targetPrice" : 8000000,
     "statusPrice" : 500,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183435",
     "siteType" : "happybean",
@@ -864,7 +874,8 @@ Content-Length: 81787
     "targetPrice" : 5000000,
     "statusPrice" : 12700,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183381",
     "siteType" : "happybean",
@@ -880,7 +891,8 @@ Content-Length: 81787
     "targetPrice" : 3000000,
     "statusPrice" : 71400,
     "percent" : 2,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183319",
     "siteType" : "happybean",
@@ -896,7 +908,8 @@ Content-Length: 81787
     "targetPrice" : 9925000,
     "statusPrice" : 26700,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183333",
     "siteType" : "happybean",
@@ -912,7 +925,8 @@ Content-Length: 81787
     "targetPrice" : 9900000,
     "statusPrice" : 128700,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183320",
     "siteType" : "happybean",
@@ -928,7 +942,8 @@ Content-Length: 81787
     "targetPrice" : 3000000,
     "statusPrice" : 2069400,
     "percent" : 68,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94371",
     "siteType" : "kakao",
@@ -944,7 +959,8 @@ Content-Length: 81787
     "targetPrice" : 2824370,
     "statusPrice" : 1056700,
     "percent" : 38,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "93946",
     "siteType" : "kakao",
@@ -960,7 +976,8 @@ Content-Length: 81787
     "targetPrice" : 9670750,
     "statusPrice" : 1403400,
     "percent" : 15,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183165",
     "siteType" : "happybean",
@@ -976,7 +993,8 @@ Content-Length: 81787
     "targetPrice" : 50000000,
     "statusPrice" : 3933400,
     "percent" : 7,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182919",
     "siteType" : "happybean",
@@ -992,7 +1010,8 @@ Content-Length: 81787
     "targetPrice" : 2000000,
     "statusPrice" : 377800,
     "percent" : 18,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182907",
     "siteType" : "happybean",
@@ -1008,7 +1027,8 @@ Content-Length: 81787
     "targetPrice" : 1000000,
     "statusPrice" : 127600,
     "percent" : 12,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182852",
     "siteType" : "happybean",
@@ -1024,7 +1044,8 @@ Content-Length: 81787
     "targetPrice" : 2000000,
     "statusPrice" : 849800,
     "percent" : 42,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "93613",
     "siteType" : "kakao",
@@ -1040,7 +1061,8 @@ Content-Length: 81787
     "targetPrice" : 7100000,
     "statusPrice" : 4891500,
     "percent" : 69,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182656",
     "siteType" : "happybean",
@@ -1056,7 +1078,8 @@ Content-Length: 81787
     "targetPrice" : 9900000,
     "statusPrice" : 3336500,
     "percent" : 33,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182318",
     "siteType" : "happybean",
@@ -1072,7 +1095,8 @@ Content-Length: 81787
     "targetPrice" : 5000000,
     "statusPrice" : 1494800,
     "percent" : 29,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   } ]
 }</code></pre>
 </div>
@@ -1187,7 +1211,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 120287
+Content-Length: 120977
 
 {
   "campaigns" : [ {
@@ -1205,7 +1229,8 @@ Content-Length: 120287
     "targetPrice" : 18000000,
     "statusPrice" : 15426500,
     "percent" : 86,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94647",
     "siteType" : "kakao",
@@ -1221,7 +1246,8 @@ Content-Length: 120287
     "targetPrice" : 3000000,
     "statusPrice" : 247100,
     "percent" : 9,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "93990",
     "siteType" : "kakao",
@@ -1237,7 +1263,8 @@ Content-Length: 120287
     "targetPrice" : 3900000,
     "statusPrice" : 945600,
     "percent" : 25,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "93536",
     "siteType" : "kakao",
@@ -1253,7 +1280,8 @@ Content-Length: 120287
     "targetPrice" : 9460000,
     "statusPrice" : 3854800,
     "percent" : 41,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183160",
     "siteType" : "happybean",
@@ -1269,7 +1297,8 @@ Content-Length: 120287
     "targetPrice" : 5540000,
     "statusPrice" : 218300,
     "percent" : 3,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183369",
     "siteType" : "happybean",
@@ -1285,7 +1314,8 @@ Content-Length: 120287
     "targetPrice" : 7300000,
     "statusPrice" : 177200,
     "percent" : 2,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94441",
     "siteType" : "kakao",
@@ -1301,7 +1331,8 @@ Content-Length: 120287
     "targetPrice" : 8000000,
     "statusPrice" : 907500,
     "percent" : 12,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183153",
     "siteType" : "happybean",
@@ -1317,7 +1348,8 @@ Content-Length: 120287
     "targetPrice" : 3000000,
     "statusPrice" : 33500,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "93678",
     "siteType" : "kakao",
@@ -1333,7 +1365,8 @@ Content-Length: 120287
     "targetPrice" : 3100000,
     "statusPrice" : 2306500,
     "percent" : 75,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183535",
     "siteType" : "happybean",
@@ -1349,7 +1382,8 @@ Content-Length: 120287
     "targetPrice" : 5000000,
     "statusPrice" : 900,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183235",
     "siteType" : "happybean",
@@ -1365,7 +1399,8 @@ Content-Length: 120287
     "targetPrice" : 2400000,
     "statusPrice" : 745600,
     "percent" : 31,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182272",
     "siteType" : "happybean",
@@ -1381,7 +1416,8 @@ Content-Length: 120287
     "targetPrice" : 2787000,
     "statusPrice" : 211700,
     "percent" : 7,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182966",
     "siteType" : "happybean",
@@ -1397,7 +1433,8 @@ Content-Length: 120287
     "targetPrice" : 6000000,
     "statusPrice" : 43400,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "93777",
     "siteType" : "kakao",
@@ -1413,7 +1450,8 @@ Content-Length: 120287
     "targetPrice" : 2131500,
     "statusPrice" : 1719800,
     "percent" : 81,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94022",
     "siteType" : "kakao",
@@ -1429,7 +1467,8 @@ Content-Length: 120287
     "targetPrice" : 7000000,
     "statusPrice" : 2437200,
     "percent" : 35,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182870",
     "siteType" : "happybean",
@@ -1445,7 +1484,8 @@ Content-Length: 120287
     "targetPrice" : 4000000,
     "statusPrice" : 884700,
     "percent" : 22,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182325",
     "siteType" : "happybean",
@@ -1461,7 +1501,8 @@ Content-Length: 120287
     "targetPrice" : 8100000,
     "statusPrice" : 1584900,
     "percent" : 19,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182925",
     "siteType" : "happybean",
@@ -1477,7 +1518,8 @@ Content-Length: 120287
     "targetPrice" : 2569000,
     "statusPrice" : 680900,
     "percent" : 26,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182921",
     "siteType" : "happybean",
@@ -1493,7 +1535,8 @@ Content-Length: 120287
     "targetPrice" : 9000000,
     "statusPrice" : 1195100,
     "percent" : 13,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183178",
     "siteType" : "happybean",
@@ -1509,7 +1552,8 @@ Content-Length: 120287
     "targetPrice" : 4000000,
     "statusPrice" : 43300,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183348",
     "siteType" : "happybean",
@@ -1525,7 +1569,8 @@ Content-Length: 120287
     "targetPrice" : 9900000,
     "statusPrice" : 1422500,
     "percent" : 14,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182664",
     "siteType" : "happybean",
@@ -1541,7 +1586,8 @@ Content-Length: 120287
     "targetPrice" : 5800000,
     "statusPrice" : 576100,
     "percent" : 9,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182493",
     "siteType" : "happybean",
@@ -1557,7 +1603,8 @@ Content-Length: 120287
     "targetPrice" : 5000000,
     "statusPrice" : 3019500,
     "percent" : 60,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183274",
     "siteType" : "happybean",
@@ -1573,7 +1620,8 @@ Content-Length: 120287
     "targetPrice" : 1000000,
     "statusPrice" : 10300,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94448",
     "siteType" : "kakao",
@@ -1589,7 +1637,8 @@ Content-Length: 120287
     "targetPrice" : 3640000,
     "statusPrice" : 1609600,
     "percent" : 45,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94512",
     "siteType" : "kakao",
@@ -1605,7 +1654,8 @@ Content-Length: 120287
     "targetPrice" : 6000000,
     "statusPrice" : 268600,
     "percent" : 5,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182674",
     "siteType" : "happybean",
@@ -1621,7 +1671,8 @@ Content-Length: 120287
     "targetPrice" : 9000000,
     "statusPrice" : 708200,
     "percent" : 7,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "93814",
     "siteType" : "kakao",
@@ -1637,7 +1688,8 @@ Content-Length: 120287
     "targetPrice" : 3000000,
     "statusPrice" : 1866900,
     "percent" : 63,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94131",
     "siteType" : "kakao",
@@ -1653,7 +1705,8 @@ Content-Length: 120287
     "targetPrice" : 6873000,
     "statusPrice" : 2922300,
     "percent" : 43,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183265",
     "siteType" : "happybean",
@@ -1669,7 +1722,8 @@ Content-Length: 120287
     "targetPrice" : 9600000,
     "statusPrice" : 4278900,
     "percent" : 44,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   } ]
 }</code></pre>
 </div>
@@ -1770,6 +1824,11 @@ Content-Length: 120287
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>campaigns.[].isHeart</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>campaigns.[].heartCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 갯수</p></td>
 </tr>
 </tbody>
 </table>
@@ -2052,7 +2111,7 @@ Host: localhost:8080
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NDg5MTcxMzd9.8gIY_de1UaRqOQl4E_LiTH5enpC6BopRDjDrdh-GFe7-Gs51nMZ258YV_vmhTyjISrHq2l8z1USzDZmjsy8TZg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NDg5NjcxODh9.Ymcqt8t6LAD2f5dDCQlR_dkTkOZNvSwxgzDOiEC8_yv1NtxSrmyp68pnpwR7prGvIKuV8wv1A9RBqi_SnhKxtA
 Content-Type: application/json
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
@@ -2063,7 +2122,7 @@ X-Frame-Options: DENY
 Content-Length: 208
 
 {
-  "token" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NDg5MTcxMzd9.8gIY_de1UaRqOQl4E_LiTH5enpC6BopRDjDrdh-GFe7-Gs51nMZ258YV_vmhTyjISrHq2l8z1USzDZmjsy8TZg"
+  "token" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NDg5NjcxODh9.Ymcqt8t6LAD2f5dDCQlR_dkTkOZNvSwxgzDOiEC8_yv1NtxSrmyp68pnpwR7prGvIKuV8wv1A9RBqi_SnhKxtA"
 }</code></pre>
 </div>
 </div>
@@ -2122,7 +2181,7 @@ Content-Length: 208
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/user/user@email.com HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NDg5MTcxMzd9.8gIY_de1UaRqOQl4E_LiTH5enpC6BopRDjDrdh-GFe7-Gs51nMZ258YV_vmhTyjISrHq2l8z1USzDZmjsy8TZg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NDg5NjcxODh9.Ymcqt8t6LAD2f5dDCQlR_dkTkOZNvSwxgzDOiEC8_yv1NtxSrmyp68pnpwR7prGvIKuV8wv1A9RBqi_SnhKxtA
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -2169,27 +2228,27 @@ Content-Length: 724
 
 {
   "user" : {
-    "id" : "3028a829-8991-4948-a8a8-2989919948c3",
+    "id" : "2f0c85a1-3136-4a6c-8c85-a13136ba6c3b",
     "email" : "user@email.com",
-    "password" : "{bcrypt}$2a$10$eVt34UJozrZAmMv4cjsROuUPXoEY3.3HrmrSprqWsal2Ddd4PYv6e",
+    "password" : "{bcrypt}$2a$10$pdT3KQxOzA4g7tY95kOO/u0egk6uJOBoXvGkxjjz.fqWKaIGBl586",
     "nickname" : "user1",
     "profile" : null,
     "sex" : "M",
     "birth" : "2000-01-01",
-    "create_date" : "2022-04-02T01:32:15",
-    "modify_date" : "2022-04-02T01:32:15",
+    "create_date" : "2022-04-02T15:26:27",
+    "modify_date" : "2022-04-02T15:26:27",
     "authorities" : [ {
       "authorityName" : "ROLE_USER"
     } ],
     "hearts" : [ ],
     "favTopic" : [ {
-      "id" : 27,
+      "id" : 57,
       "topic" : {
         "id" : 1,
         "topicName" : "아동|청소년"
       }
     }, {
-      "id" : 28,
+      "id" : 58,
       "topic" : {
         "id" : 2,
         "topicName" : "어르신"
@@ -2456,7 +2515,7 @@ Content-Length: 92
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-04-02 01:06:34 +0900
+Last updated 2022-04-02 14:22:50 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/main/java/com/hsu/mamomo/controller/Heartcontroller.java
+++ b/src/main/java/com/hsu/mamomo/controller/Heartcontroller.java
@@ -21,12 +21,6 @@ public class Heartcontroller {
 
     private final HeartService heartService;
 
-    /*
-     * 리턴 형식같은것은 추후에 수정 할 예정!!
-     * 일단 기능 구현 먼저 하였음..
-     * user 검증 과정 필요함!
-     * */
-
     @PostMapping
     public ResponseEntity<HeartDto> heart(@RequestBody @Valid HeartDto heartDto) {
         heartService.heart(heartDto);

--- a/src/main/java/com/hsu/mamomo/domain/Campaign.java
+++ b/src/main/java/com/hsu/mamomo/domain/Campaign.java
@@ -70,4 +70,6 @@ public class Campaign {
 
     private Boolean isHeart = false;
 
+    private Integer heartCount = 0;
+
 }

--- a/src/main/java/com/hsu/mamomo/domain/User.java
+++ b/src/main/java/com/hsu/mamomo/domain/User.java
@@ -70,12 +70,11 @@ public class User {
             cascade = CascadeType.ALL,
             orphanRemoval = true,
             fetch = FetchType.LAZY)
-    private List<Heart> hearts = new ArrayList<>();
-
+    private List<Heart> hearts;
     @OneToMany(
             mappedBy = "user",
             cascade = CascadeType.ALL,
             orphanRemoval = true,
             fetch = FetchType.LAZY)
-    private List<FavTopic> favTopic = new ArrayList<>();
+    private List<FavTopic> favTopic;
 }

--- a/src/main/java/com/hsu/mamomo/repository/jpa/HeartRepository.java
+++ b/src/main/java/com/hsu/mamomo/repository/jpa/HeartRepository.java
@@ -2,11 +2,11 @@ package com.hsu.mamomo.repository.jpa;
 
 import com.hsu.mamomo.domain.Heart;
 import com.hsu.mamomo.domain.User;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface HeartRepository extends JpaRepository<Heart, Long> {
 
     Optional<Heart> findHeartByUserAndCampaignId(User user, String campaignId);
-
 }

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -748,6 +748,11 @@ Host: localhost:8080</code></pre>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 여부</p></td>
 </tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>campaigns.[].heartCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 갯수</p></td>
+</tr>
 </tbody>
 </table>
 </div>
@@ -766,7 +771,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 81787
+Content-Length: 82224
 
 {
   "campaigns" : [ {
@@ -784,7 +789,8 @@ Content-Length: 81787
     "targetPrice" : 2000000,
     "statusPrice" : 200,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94511",
     "siteType" : "kakao",
@@ -800,7 +806,8 @@ Content-Length: 81787
     "targetPrice" : 1168000,
     "statusPrice" : 251600,
     "percent" : 22,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94817",
     "siteType" : "kakao",
@@ -816,7 +823,8 @@ Content-Length: 81787
     "targetPrice" : 700000000,
     "statusPrice" : 555462400,
     "percent" : 80,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94598",
     "siteType" : "kakao",
@@ -832,7 +840,8 @@ Content-Length: 81787
     "targetPrice" : 10000000,
     "statusPrice" : 293400,
     "percent" : 3,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183433",
     "siteType" : "happybean",
@@ -848,7 +857,8 @@ Content-Length: 81787
     "targetPrice" : 8000000,
     "statusPrice" : 500,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183435",
     "siteType" : "happybean",
@@ -864,7 +874,8 @@ Content-Length: 81787
     "targetPrice" : 5000000,
     "statusPrice" : 12700,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183381",
     "siteType" : "happybean",
@@ -880,7 +891,8 @@ Content-Length: 81787
     "targetPrice" : 3000000,
     "statusPrice" : 71400,
     "percent" : 2,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183319",
     "siteType" : "happybean",
@@ -896,7 +908,8 @@ Content-Length: 81787
     "targetPrice" : 9925000,
     "statusPrice" : 26700,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183333",
     "siteType" : "happybean",
@@ -912,7 +925,8 @@ Content-Length: 81787
     "targetPrice" : 9900000,
     "statusPrice" : 128700,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183320",
     "siteType" : "happybean",
@@ -928,7 +942,8 @@ Content-Length: 81787
     "targetPrice" : 3000000,
     "statusPrice" : 2069400,
     "percent" : 68,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94371",
     "siteType" : "kakao",
@@ -944,7 +959,8 @@ Content-Length: 81787
     "targetPrice" : 2824370,
     "statusPrice" : 1056700,
     "percent" : 38,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "93946",
     "siteType" : "kakao",
@@ -960,7 +976,8 @@ Content-Length: 81787
     "targetPrice" : 9670750,
     "statusPrice" : 1403400,
     "percent" : 15,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183165",
     "siteType" : "happybean",
@@ -976,7 +993,8 @@ Content-Length: 81787
     "targetPrice" : 50000000,
     "statusPrice" : 3933400,
     "percent" : 7,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182919",
     "siteType" : "happybean",
@@ -992,7 +1010,8 @@ Content-Length: 81787
     "targetPrice" : 2000000,
     "statusPrice" : 377800,
     "percent" : 18,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182907",
     "siteType" : "happybean",
@@ -1008,7 +1027,8 @@ Content-Length: 81787
     "targetPrice" : 1000000,
     "statusPrice" : 127600,
     "percent" : 12,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182852",
     "siteType" : "happybean",
@@ -1024,7 +1044,8 @@ Content-Length: 81787
     "targetPrice" : 2000000,
     "statusPrice" : 849800,
     "percent" : 42,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "93613",
     "siteType" : "kakao",
@@ -1040,7 +1061,8 @@ Content-Length: 81787
     "targetPrice" : 7100000,
     "statusPrice" : 4891500,
     "percent" : 69,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182656",
     "siteType" : "happybean",
@@ -1056,7 +1078,8 @@ Content-Length: 81787
     "targetPrice" : 9900000,
     "statusPrice" : 3336500,
     "percent" : 33,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182318",
     "siteType" : "happybean",
@@ -1072,7 +1095,8 @@ Content-Length: 81787
     "targetPrice" : 5000000,
     "statusPrice" : 1494800,
     "percent" : 29,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   } ]
 }</code></pre>
 </div>
@@ -1187,7 +1211,7 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 120287
+Content-Length: 120977
 
 {
   "campaigns" : [ {
@@ -1205,7 +1229,8 @@ Content-Length: 120287
     "targetPrice" : 18000000,
     "statusPrice" : 15426500,
     "percent" : 86,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94647",
     "siteType" : "kakao",
@@ -1221,7 +1246,8 @@ Content-Length: 120287
     "targetPrice" : 3000000,
     "statusPrice" : 247100,
     "percent" : 9,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "93990",
     "siteType" : "kakao",
@@ -1237,7 +1263,8 @@ Content-Length: 120287
     "targetPrice" : 3900000,
     "statusPrice" : 945600,
     "percent" : 25,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "93536",
     "siteType" : "kakao",
@@ -1253,7 +1280,8 @@ Content-Length: 120287
     "targetPrice" : 9460000,
     "statusPrice" : 3854800,
     "percent" : 41,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183160",
     "siteType" : "happybean",
@@ -1269,7 +1297,8 @@ Content-Length: 120287
     "targetPrice" : 5540000,
     "statusPrice" : 218300,
     "percent" : 3,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183369",
     "siteType" : "happybean",
@@ -1285,7 +1314,8 @@ Content-Length: 120287
     "targetPrice" : 7300000,
     "statusPrice" : 177200,
     "percent" : 2,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94441",
     "siteType" : "kakao",
@@ -1301,7 +1331,8 @@ Content-Length: 120287
     "targetPrice" : 8000000,
     "statusPrice" : 907500,
     "percent" : 12,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183153",
     "siteType" : "happybean",
@@ -1317,7 +1348,8 @@ Content-Length: 120287
     "targetPrice" : 3000000,
     "statusPrice" : 33500,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "93678",
     "siteType" : "kakao",
@@ -1333,7 +1365,8 @@ Content-Length: 120287
     "targetPrice" : 3100000,
     "statusPrice" : 2306500,
     "percent" : 75,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183535",
     "siteType" : "happybean",
@@ -1349,7 +1382,8 @@ Content-Length: 120287
     "targetPrice" : 5000000,
     "statusPrice" : 900,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183235",
     "siteType" : "happybean",
@@ -1365,7 +1399,8 @@ Content-Length: 120287
     "targetPrice" : 2400000,
     "statusPrice" : 745600,
     "percent" : 31,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182272",
     "siteType" : "happybean",
@@ -1381,7 +1416,8 @@ Content-Length: 120287
     "targetPrice" : 2787000,
     "statusPrice" : 211700,
     "percent" : 7,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182966",
     "siteType" : "happybean",
@@ -1397,7 +1433,8 @@ Content-Length: 120287
     "targetPrice" : 6000000,
     "statusPrice" : 43400,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "93777",
     "siteType" : "kakao",
@@ -1413,7 +1450,8 @@ Content-Length: 120287
     "targetPrice" : 2131500,
     "statusPrice" : 1719800,
     "percent" : 81,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94022",
     "siteType" : "kakao",
@@ -1429,7 +1467,8 @@ Content-Length: 120287
     "targetPrice" : 7000000,
     "statusPrice" : 2437200,
     "percent" : 35,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182870",
     "siteType" : "happybean",
@@ -1445,7 +1484,8 @@ Content-Length: 120287
     "targetPrice" : 4000000,
     "statusPrice" : 884700,
     "percent" : 22,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182325",
     "siteType" : "happybean",
@@ -1461,7 +1501,8 @@ Content-Length: 120287
     "targetPrice" : 8100000,
     "statusPrice" : 1584900,
     "percent" : 19,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182925",
     "siteType" : "happybean",
@@ -1477,7 +1518,8 @@ Content-Length: 120287
     "targetPrice" : 2569000,
     "statusPrice" : 680900,
     "percent" : 26,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182921",
     "siteType" : "happybean",
@@ -1493,7 +1535,8 @@ Content-Length: 120287
     "targetPrice" : 9000000,
     "statusPrice" : 1195100,
     "percent" : 13,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183178",
     "siteType" : "happybean",
@@ -1509,7 +1552,8 @@ Content-Length: 120287
     "targetPrice" : 4000000,
     "statusPrice" : 43300,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183348",
     "siteType" : "happybean",
@@ -1525,7 +1569,8 @@ Content-Length: 120287
     "targetPrice" : 9900000,
     "statusPrice" : 1422500,
     "percent" : 14,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182664",
     "siteType" : "happybean",
@@ -1541,7 +1586,8 @@ Content-Length: 120287
     "targetPrice" : 5800000,
     "statusPrice" : 576100,
     "percent" : 9,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182493",
     "siteType" : "happybean",
@@ -1557,7 +1603,8 @@ Content-Length: 120287
     "targetPrice" : 5000000,
     "statusPrice" : 3019500,
     "percent" : 60,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183274",
     "siteType" : "happybean",
@@ -1573,7 +1620,8 @@ Content-Length: 120287
     "targetPrice" : 1000000,
     "statusPrice" : 10300,
     "percent" : 1,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94448",
     "siteType" : "kakao",
@@ -1589,7 +1637,8 @@ Content-Length: 120287
     "targetPrice" : 3640000,
     "statusPrice" : 1609600,
     "percent" : 45,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94512",
     "siteType" : "kakao",
@@ -1605,7 +1654,8 @@ Content-Length: 120287
     "targetPrice" : 6000000,
     "statusPrice" : 268600,
     "percent" : 5,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000182674",
     "siteType" : "happybean",
@@ -1621,7 +1671,8 @@ Content-Length: 120287
     "targetPrice" : 9000000,
     "statusPrice" : 708200,
     "percent" : 7,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "93814",
     "siteType" : "kakao",
@@ -1637,7 +1688,8 @@ Content-Length: 120287
     "targetPrice" : 3000000,
     "statusPrice" : 1866900,
     "percent" : 63,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "94131",
     "siteType" : "kakao",
@@ -1653,7 +1705,8 @@ Content-Length: 120287
     "targetPrice" : 6873000,
     "statusPrice" : 2922300,
     "percent" : 43,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   }, {
     "id" : "H000000183265",
     "siteType" : "happybean",
@@ -1669,7 +1722,8 @@ Content-Length: 120287
     "targetPrice" : 9600000,
     "statusPrice" : 4278900,
     "percent" : 44,
-    "isHeart" : false
+    "isHeart" : false,
+    "heartCount" : 0
   } ]
 }</code></pre>
 </div>
@@ -1770,6 +1824,11 @@ Content-Length: 120287
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>campaigns.[].isHeart</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>campaigns.[].heartCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">좋아요 갯수</p></td>
 </tr>
 </tbody>
 </table>
@@ -2052,7 +2111,7 @@ Host: localhost:8080
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NDg5MTcxMzd9.8gIY_de1UaRqOQl4E_LiTH5enpC6BopRDjDrdh-GFe7-Gs51nMZ258YV_vmhTyjISrHq2l8z1USzDZmjsy8TZg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NDg5Njc0NTh9.rkZLZ4jwBj3p4OEu0cIEFPjkmgLo4lO-c6giGX9Y80Tow2y0qESL_QPaBbzlXvi65cgP2u7s4LpkLBSX0GpOew
 Content-Type: application/json
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
@@ -2063,7 +2122,7 @@ X-Frame-Options: DENY
 Content-Length: 208
 
 {
-  "token" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NDg5MTcxMzd9.8gIY_de1UaRqOQl4E_LiTH5enpC6BopRDjDrdh-GFe7-Gs51nMZ258YV_vmhTyjISrHq2l8z1USzDZmjsy8TZg"
+  "token" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NDg5Njc0NTh9.rkZLZ4jwBj3p4OEu0cIEFPjkmgLo4lO-c6giGX9Y80Tow2y0qESL_QPaBbzlXvi65cgP2u7s4LpkLBSX0GpOew"
 }</code></pre>
 </div>
 </div>
@@ -2122,7 +2181,7 @@ Content-Length: 208
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/user/user@email.com HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NDg5MTcxMzd9.8gIY_de1UaRqOQl4E_LiTH5enpC6BopRDjDrdh-GFe7-Gs51nMZ258YV_vmhTyjISrHq2l8z1USzDZmjsy8TZg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NDg5Njc0NTh9.rkZLZ4jwBj3p4OEu0cIEFPjkmgLo4lO-c6giGX9Y80Tow2y0qESL_QPaBbzlXvi65cgP2u7s4LpkLBSX0GpOew
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -2169,27 +2228,27 @@ Content-Length: 724
 
 {
   "user" : {
-    "id" : "3028a829-8991-4948-a8a8-2989919948c3",
+    "id" : "1e1fefb4-2899-4406-9fef-b42899b4060e",
     "email" : "user@email.com",
-    "password" : "{bcrypt}$2a$10$eVt34UJozrZAmMv4cjsROuUPXoEY3.3HrmrSprqWsal2Ddd4PYv6e",
+    "password" : "{bcrypt}$2a$10$bb1evePV8Xaew.6kflq/jeZlsf24OsUEVz0NAd0nZTdGTOQbKTLri",
     "nickname" : "user1",
     "profile" : null,
     "sex" : "M",
     "birth" : "2000-01-01",
-    "create_date" : "2022-04-02T01:32:15",
-    "modify_date" : "2022-04-02T01:32:15",
+    "create_date" : "2022-04-02T15:30:57",
+    "modify_date" : "2022-04-02T15:30:57",
     "authorities" : [ {
       "authorityName" : "ROLE_USER"
     } ],
     "hearts" : [ ],
     "favTopic" : [ {
-      "id" : 27,
+      "id" : 65,
       "topic" : {
         "id" : 1,
         "topicName" : "아동|청소년"
       }
     }, {
-      "id" : 28,
+      "id" : 66,
       "topic" : {
         "id" : 2,
         "topicName" : "어르신"
@@ -2456,7 +2515,7 @@ Content-Length: 92
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-04-02 01:06:34 +0900
+Last updated 2022-04-02 14:22:50 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/java/com/hsu/mamomo/controller/CampaignControllerTest.java
+++ b/src/test/java/com/hsu/mamomo/controller/CampaignControllerTest.java
@@ -58,6 +58,7 @@ class CampaignControllerTest {
                 .andExpect(jsonPath("$.campaigns.[0].['statusPrice']").isNumber())
                 .andExpect(jsonPath("$.campaigns.[0].['percent']").isNumber())
                 .andExpect(jsonPath("$.campaigns.[0].['isHeart']").isBoolean())
+                .andExpect(jsonPath("$.campaigns.[0].['heartCount']").isNumber())
                 .andDo(document("campaigns",
                         getDocumentRequest(),
                         getDocumentResponse(),
@@ -120,7 +121,9 @@ class CampaignControllerTest {
                                 fieldWithPath("campaigns.[].percent").type(JsonFieldType.NUMBER)
                                         .description("달성 정도"),
                                 fieldWithPath("campaigns.[].isHeart").type(JsonFieldType.BOOLEAN)
-                                        .description("좋아요 여부")
+                                        .description("좋아요 여부"),
+                                fieldWithPath("campaigns.[].heartCount").type(JsonFieldType.NUMBER)
+                                        .description("좋아요 갯수")
                         )
                 ));
     }

--- a/src/test/java/com/hsu/mamomo/controller/CampaignSearchControllerTest.java
+++ b/src/test/java/com/hsu/mamomo/controller/CampaignSearchControllerTest.java
@@ -74,6 +74,7 @@ class CampaignSearchControllerTest {
                 .andExpect(jsonPath("$.campaigns.[0].['statusPrice']").isNumber())
                 .andExpect(jsonPath("$.campaigns.[0].['percent']").isNumber())
                 .andExpect(jsonPath("$.campaigns.[0].['isHeart']").isBoolean())
+                .andExpect(jsonPath("$.campaigns.[0].['heartCount']").isNumber())
 
                 .andDo(document("search-campaigns-by-keyword",
                         getDocumentRequest(),
@@ -125,7 +126,9 @@ class CampaignSearchControllerTest {
                                 fieldWithPath("campaigns.[].percent").type(JsonFieldType.NUMBER)
                                         .description("달성 정도"),
                                 fieldWithPath("campaigns.[].isHeart").type(JsonFieldType.BOOLEAN)
-                                        .description("좋아요 여부")
+                                        .description("좋아요 여부"),
+                                fieldWithPath("campaigns.[].heartCount").type(JsonFieldType.NUMBER)
+                                        .description("좋아요 갯수")
                         )));
     }
 }

--- a/src/test/java/com/hsu/mamomo/controller/HeartControllerTest.java
+++ b/src/test/java/com/hsu/mamomo/controller/HeartControllerTest.java
@@ -12,10 +12,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hsu.mamomo.config.jpa.JpaConfig;
 import com.hsu.mamomo.domain.Campaign;
+import com.hsu.mamomo.domain.Heart;
 import com.hsu.mamomo.repository.elastic.CampaignRepository;
+import com.hsu.mamomo.repository.jpa.HeartRepository;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.elasticsearch.ResourceNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -42,6 +46,8 @@ public class HeartControllerTest {
     private MockMvc mockMvc;
     @Autowired
     private CampaignRepository campaignRepository;
+    @Autowired
+    private HeartRepository heartRepository;
 
     ObjectMapper objectMapper = new ObjectMapper();
     Map<String, String> input = new HashMap<>();
@@ -98,6 +104,13 @@ public class HeartControllerTest {
                                 fieldWithPath("userId").description("좋아요 취소 누르는 유저 ID")
                         )));
 
+    }
+
+    @Test
+    public void countHeartGroupingByCampaignId() {
+        List<Heart> hearts = heartRepository.findAll();
+        Map<String, List<Heart>> heartsMap = hearts.stream().collect(Collectors.groupingBy(Heart::getCampaignId));
+        System.out.println("heartsMap = " + heartsMap);
     }
 
 }


### PR DESCRIPTION
###  좋아요 갯수
**CampaginService.java**
```java
List<Heart> hearts = heartRepository.findAll();
        Map<String, List<Heart>> heartMap = hearts.stream()
                .collect(Collectors.groupingBy(Heart::getCampaignId));
        heartMap.keySet().forEach(campaignId -> {
            int count = heartMap.get(campaignId).size(); // 해당 캠페인 좋아요 수
            Optional<Campaign> campaignOpt = campaignDto.getCampaigns().stream()
                    .filter(v -> v.getId().equals(campaignId))
                    .findFirst();
            campaignOpt.ifPresent(campaign -> campaign.setHeartCount(count));
        });
```
1. 모든 Heart 테이블 가져옴
2. 캠페인 아이디 기준으로 그루핑
3. `keySet()` 으로 반복문 돌며 해당 캠페인의 좋아요 갯수 세팅

- 동일한 내용을 Search서비스에도 넣어야 함. (좋아요 갯수 외에 좋아요 여부 체크, 로그인/로그인안함으로 나눔 등.. 동일한 부분 한번씩 더 써줘야함)
- 일단은 `/api/campagins` 에만 구현 해 놓음