### PR TITLE
Text mining

### DIFF
--- a/src/main/java/com/hsu/mamomo/controller/TextMiningController.java
+++ b/src/main/java/com/hsu/mamomo/controller/TextMiningController.java
@@ -1,0 +1,29 @@
+package com.hsu.mamomo.controller;
+
+import com.hsu.mamomo.dto.CampaignDto;
+import com.hsu.mamomo.dto.TextDto;
+import com.hsu.mamomo.service.TextMiningService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RequestMapping("/api/textMining")
+@RestController
+public class TextMiningController {
+
+    private final TextMiningService textMiningService;
+
+    @PostMapping
+    public CampaignDto textMining(
+            @PageableDefault(size = 20) Pageable pageable, @RequestBody TextDto textDto) {
+        return textMiningService.requestTextMining(pageable,textDto);
+    }
+
+}

--- a/src/main/java/com/hsu/mamomo/dto/TextDto.java
+++ b/src/main/java/com/hsu/mamomo/dto/TextDto.java
@@ -1,0 +1,17 @@
+package com.hsu.mamomo.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TextDto {
+
+    private String text;
+}

--- a/src/main/java/com/hsu/mamomo/dto/TextMiningResultDto.java
+++ b/src/main/java/com/hsu/mamomo/dto/TextMiningResultDto.java
@@ -1,0 +1,18 @@
+package com.hsu.mamomo.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class TextMiningResultDto {
+
+    private List<String> result;
+}

--- a/src/main/java/com/hsu/mamomo/service/TextMiningService.java
+++ b/src/main/java/com/hsu/mamomo/service/TextMiningService.java
@@ -1,0 +1,54 @@
+package com.hsu.mamomo.service;
+
+import com.hsu.mamomo.domain.Campaign;
+import com.hsu.mamomo.dto.CampaignDto;
+import com.hsu.mamomo.dto.TextDto;
+import com.hsu.mamomo.dto.TextMiningResultDto;
+import com.hsu.mamomo.service.factory.ElasticTextMiningFactory;
+import java.net.URI;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.http.RequestEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class TextMiningService {
+
+    @Value("http://127.0.0.1:5000")
+    private String flaskApiUrl;
+
+    private final ElasticTextMiningFactory textMiningFactory;
+
+    public CampaignDto requestTextMining(Pageable pageable, TextDto textDto) {
+        URI uri = UriComponentsBuilder
+                .fromUriString(flaskApiUrl)
+                .path("/")
+                .build()
+                .toUri();
+
+        RequestEntity<TextDto> requestEntity = RequestEntity
+                .post(uri)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(textDto);
+
+        RestTemplate restTemplate = new RestTemplate();
+        TextMiningResultDto textMiningResultDto = restTemplate.exchange(requestEntity, TextMiningResultDto.class).getBody();
+        return getCampaignsByTextMining(textMiningResultDto, pageable);
+    }
+
+    public CampaignDto getCampaignsByTextMining(TextMiningResultDto textMiningResultDto, Pageable pageable) {
+        return new CampaignDto(findCampaignsByTextMining(textMiningResultDto, pageable));
+    }
+
+    public Page<Campaign> findCampaignsByTextMining(TextMiningResultDto textMiningResultDto, Pageable pageable) {
+        return textMiningFactory.getCampaignSearchList(textMiningFactory.createQuery(textMiningResultDto,pageable));
+    }
+}

--- a/src/main/java/com/hsu/mamomo/service/factory/ElasticTextMiningFactory.java
+++ b/src/main/java/com/hsu/mamomo/service/factory/ElasticTextMiningFactory.java
@@ -1,0 +1,35 @@
+package com.hsu.mamomo.service.factory;
+
+import com.hsu.mamomo.dto.TextMiningResultDto;
+import java.util.List;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQueryBuilder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ElasticTextMiningFactory extends ElasticSortFactory {
+
+    public ElasticTextMiningFactory(
+            ElasticsearchOperations elasticsearchOperations) {
+        super(elasticsearchOperations);
+    }
+
+    @Override
+    public NativeSearchQuery createQuery(Object textMiningResultDto, Pageable pageable) {
+        List<String> textMiningResults = ((TextMiningResultDto) textMiningResultDto).getResult();
+
+        NativeSearchQueryBuilder queryBuilder = new NativeSearchQueryBuilder()
+                .withQuery(
+                        QueryBuilders.boolQuery()
+                                .must(QueryBuilders.termsQuery("body", textMiningResults.get(0)))
+                                .should(QueryBuilders.termQuery("body", textMiningResults.get(1)))
+                                .should(QueryBuilders.termQuery("body", textMiningResults.get(2)))
+                )
+                .withPageable(pageable);
+
+        return queryBuilder.build();
+    }
+}


### PR DESCRIPTION
**TextMiningController**: Client의 `POST /api/textMining`로 온 텍스트(`TextDto`)를 받는다. 
**TextMiningService**의 `requestTextMining()`를 호출해(텍스트 마이닝 과정) `CampaignDto`를 반환한다. 

**TextMiningService**의 `requestTextMining()`: Flask에 `TextDto`를 보내며 요청, `TextMiningResultDto`로 응답 받음 

**ElasticTextMiningFactory**는 `TextMiningResultDto`로 ES에 가중치(must,should)를 부여해 캠페인 검색 (가중치는 임의로 설정함, 후에 수정필요)