### PR TITLE
좋아요 api 유저 인증 로직 추가

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -541,6 +541,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_좋아요">5.1. 좋아요</a>
 <ul class="sectlevel3">
 <li><a href="#_요청_12">요청</a></li>
+<li><a href="#_요청_헤더_2">요청 헤더</a></li>
 <li><a href="#_요청_필드_4">요청 필드</a></li>
 <li><a href="#_응답_6">응답</a></li>
 </ul>
@@ -594,7 +595,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/campaigns?page=0&amp;size=3&amp;sort=due_date%2CDESC&amp;category=1 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NTEyMTc4NjF9.SOwYyO2bPs8gDIMMUyxg7JH_P5y50UbrlEJJm0IRPAEkwNqVIXj-0Z9ZegisUvjHH82QRvr_TDMcnFfo0j14dA
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NTEyODc5NTd9.dUEs78AiW7kqLLAUDcaBzj4KsCmyV1PsyvJeyId7SNfIc2vKLnszZUTAMj_x_R_LgHxX7SojeooHm1XxJEKDvg
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -979,8 +980,8 @@ Content-Length: 9116
         "unsorted" : false
       },
       "offset" : 0,
-      "pageNumber" : 0,
       "pageSize" : 3,
+      "pageNumber" : 0,
       "paged" : true,
       "unpaged" : false
     },
@@ -1094,7 +1095,7 @@ Host: localhost:8080</code></pre>
 <h4 id="_요청_4"><a class="link" href="#_요청_4">요청</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/campaign/94032 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/campaign/94323 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Host: localhost:8080</code></pre>
 </div>
@@ -1509,7 +1510,7 @@ Host: localhost:8080
 Vary: Origin
 Vary: Access-Control-Request-Method
 Vary: Access-Control-Request-Headers
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NTEyMTc4NjZ9.SakzTsjFEw5cCuFFMr7fOXwRau2R48j1jRWF-e6IAYlTAe5QjtcgmxApNIY-sWcPBa6jGGZpQ0jCz-lO0HkeDg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NTEyODc5Njl9._V4PV0PrwWYwZwPmWnrXVpP6m4XXIw7aiw7S4BGpBRO7bK-fTSRC3NjwN73DaoV68-br89oB2VDCT9cCoGtuug
 Content-Type: application/json
 X-Content-Type-Options: nosniff
 X-XSS-Protection: 1; mode=block
@@ -1520,7 +1521,7 @@ X-Frame-Options: DENY
 Content-Length: 208
 
 {
-  "token" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NTEyMTc4NjZ9.SakzTsjFEw5cCuFFMr7fOXwRau2R48j1jRWF-e6IAYlTAe5QjtcgmxApNIY-sWcPBa6jGGZpQ0jCz-lO0HkeDg"
+  "token" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NTEyODc5Njl9._V4PV0PrwWYwZwPmWnrXVpP6m4XXIw7aiw7S4BGpBRO7bK-fTSRC3NjwN73DaoV68-br89oB2VDCT9cCoGtuug"
 }</code></pre>
 </div>
 </div>
@@ -1579,7 +1580,7 @@ Content-Length: 208
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/user/user@email.com HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NTEyMTc4NjZ9.SakzTsjFEw5cCuFFMr7fOXwRau2R48j1jRWF-e6IAYlTAe5QjtcgmxApNIY-sWcPBa6jGGZpQ0jCz-lO0HkeDg
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ1c2VyQGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NTEyODc5Njl9._V4PV0PrwWYwZwPmWnrXVpP6m4XXIw7aiw7S4BGpBRO7bK-fTSRC3NjwN73DaoV68-br89oB2VDCT9cCoGtuug
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1626,27 +1627,27 @@ Content-Length: 724
 
 {
   "user" : {
-    "id" : "4ecca698-6c30-4f7c-8ca6-986c302f7c7a",
+    "id" : "62bdad56-760b-4b3b-bdad-56760beb3b2f",
     "email" : "user@email.com",
-    "password" : "{bcrypt}$2a$10$Fqxrf0kxI8cVSJq6lqsoWe3OF/WKhEhCajW/CfIquBH9DPlle11qW",
+    "password" : "{bcrypt}$2a$10$pyw8e9PwZxCf3/RhwF.Ui.yknYawDga72d4LaTCayehj3OGfSLEzq",
     "nickname" : "user1",
     "profile" : null,
     "sex" : "M",
     "birth" : "2000-01-01",
-    "create_date" : "2022-04-28T16:37:41",
-    "modify_date" : "2022-04-28T16:37:41",
+    "create_date" : "2022-04-29T12:06:08",
+    "modify_date" : "2022-04-29T12:06:08",
     "authorities" : [ {
       "authorityName" : "ROLE_USER"
     } ],
     "hearts" : [ ],
     "favTopic" : [ {
-      "id" : 47,
+      "id" : 59,
       "topic" : {
         "id" : 1,
         "topicName" : "아동|청소년"
       }
     }, {
-      "id" : 48,
+      "id" : 60,
       "topic" : {
         "id" : 2,
         "topicName" : "어르신"
@@ -1758,15 +1759,38 @@ Content-Length: 724
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/heart HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 84
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NTEyODc5NjN9.iXCXvCuNWGiIe8DQAHa0mjnuJHHN5-NcRKtQJNq2yED6BW2jcbK5wPFb2qsQyhAX4WuL138BdemRUqBEgwxx_A
+Content-Length: 92
 Host: localhost:8080
 
 {
-  "campaignId" : "94464",
+  "campaignId" : "H000000184164",
   "userId" : "550e8400-e29b-41d4-a716-446655440000"
 }</code></pre>
 </div>
 </div>
+</div>
+<div class="sect3">
+<h4 id="_요청_헤더_2"><a class="link" href="#_요청_헤더_2">요청 헤더</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">발급받은 jwt 토큰.</p>
+<p class="tableblock">토큰 앞에 'Bearer '을 붙인다.</p></td>
+</tr>
+</tbody>
+</table>
 </div>
 <div class="sect3">
 <h4 id="_요청_필드_4"><a class="link" href="#_요청_필드_4">요청 필드</a></h4>
@@ -1820,10 +1844,10 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 84
+Content-Length: 92
 
 {
-  "campaignId" : "94464",
+  "campaignId" : "H000000184164",
   "userId" : "550e8400-e29b-41d4-a716-446655440000"
 }</code></pre>
 </div>
@@ -1838,11 +1862,12 @@ Content-Length: 84
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">DELETE /api/heart HTTP/1.1
 Content-Type: application/json;charset=UTF-8
-Content-Length: 84
+Authorization: Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0ZXN0QGVtYWlsLmNvbSIsImF1dGgiOiJST0xFX1VTRVIiLCJleHAiOjE2NTEyODc5NjV9.J40Jvt0Ad0xiUuELn0ytFq-IhhFrEIvTdsWBudbNlQi_8nPuwUlUCYn7N2o46GdiVENDslGD5EZkk2m7m8UwcA
+Content-Length: 92
 Host: localhost:8080
 
 {
-  "campaignId" : "94464",
+  "campaignId" : "H000000184164",
   "userId" : "550e8400-e29b-41d4-a716-446655440000"
 }</code></pre>
 </div>
@@ -1850,6 +1875,9 @@ Host: localhost:8080
 </div>
 <div class="sect3">
 <h4 id="_요청_필드_5"><a class="link" href="#_요청_필드_5">요청 필드</a></h4>
+<div class="paragraph">
+<p>요청 헤더는 좋아요 요청 해더와 동일</p>
+</div>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -1900,10 +1928,10 @@ Cache-Control: no-cache, no-store, max-age=0, must-revalidate
 Pragma: no-cache
 Expires: 0
 X-Frame-Options: DENY
-Content-Length: 84
+Content-Length: 92
 
 {
-  "campaignId" : "94464",
+  "campaignId" : "H000000184164",
   "userId" : "550e8400-e29b-41d4-a716-446655440000"
 }</code></pre>
 </div>
@@ -1946,6 +1974,11 @@ Content-Length: 84
 <td class="tableblock halign-left valign-top"><p class="tableblock">400</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">INVALID_JWT_TOKEN</p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">유효하지 않은 JWT 토큰입니다.</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock">400</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">MISMATCH_JWT_USER</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">jwt 토큰과 요청 유저가 일치하지 않습니다.</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock">404</p></td>
@@ -1995,7 +2028,7 @@ Content-Length: 84
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2022-04-28 16:35:44 +0900
+Last updated 2022-04-29 12:05:26 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -217,6 +217,9 @@ include::{snippets}/get-user-info-with-jwtToken/response-fields.adoc[]
 ==== 요청
 include::{snippets}/doHeart-success/http-request.adoc[]
 
+==== 요청 헤더
+include::{snippets}/doHeart-success/request-headers.adoc[]
+
 ==== 요청 필드
 include::{snippets}/doHeart-success/request-fields.adoc[]
 
@@ -229,6 +232,7 @@ include::{snippets}/doHeart-success/http-response.adoc[]
 include::{snippets}/unHeart-success/http-request.adoc[]
 
 ==== 요청 필드
+요청 헤더는 좋아요 요청 해더와 동일
 include::{snippets}/unHeart-success/request-fields.adoc[]
 
 ==== 응답
@@ -254,6 +258,10 @@ include::{snippets}/unHeart-success/http-response.adoc[]
 |400
 |INVALID_JWT_TOKEN
 |유효하지 않은 JWT 토큰입니다.
+
+|400
+|MISMATCH_JWT_USER
+|jwt 토큰과 요청 유저가 일치하지 않습니다.
 
 |404
 |MEMBER_NOT_FOUND

--- a/src/main/generated/META-INF/MANIFEST.MF
+++ b/src/main/generated/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: com.hsu.mamomo.MamomoApplication
+

--- a/src/main/java/com/hsu/mamomo/controller/HeartController.java
+++ b/src/main/java/com/hsu/mamomo/controller/HeartController.java
@@ -1,16 +1,22 @@
 package com.hsu.mamomo.controller;
 
+import static com.hsu.mamomo.controller.exception.ErrorCode.UNAUTHORIZED;
+
+import com.hsu.mamomo.controller.exception.CustomException;
 import com.hsu.mamomo.dto.HeartDto;
 import com.hsu.mamomo.service.HeartService;
 import java.io.IOException;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,17 +28,33 @@ public class HeartController {
 
     private final HeartService heartService;
 
+    @PreAuthorize("hasAnyRole('USER')")
     @PostMapping
-    public ResponseEntity<HeartDto> heart(@RequestBody @Valid HeartDto heartDto)
+    public ResponseEntity<HeartDto> heart(@RequestBody @Valid HeartDto heartDto,
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization)
             throws IOException {
-        heartService.heart(heartDto);
+
+        if (authorization == null) {
+            throw new CustomException(UNAUTHORIZED);
+        }
+
+        heartService.heart(heartDto, authorization.substring(7));
+
         return new ResponseEntity<>(heartDto, HttpStatus.CREATED);
     }
 
+    @PreAuthorize("hasAnyRole('USER')")
     @DeleteMapping
-    public ResponseEntity<HeartDto> unHeart(@RequestBody @Valid HeartDto heartDto)
+    public ResponseEntity<HeartDto> unHeart(@RequestBody @Valid HeartDto heartDto,
+            @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authorization)
             throws IOException {
-        heartService.unHeart(heartDto);
+
+        if (authorization == null) {
+            throw new CustomException(UNAUTHORIZED);
+        }
+
+        heartService.unHeart(heartDto, authorization.substring(7));
+
         return new ResponseEntity<>(heartDto, HttpStatus.OK);
     }
 

--- a/src/main/java/com/hsu/mamomo/controller/exception/ErrorCode.java
+++ b/src/main/java/com/hsu/mamomo/controller/exception/ErrorCode.java
@@ -12,6 +12,10 @@ public enum ErrorCode {
     WRONG_OBJECT(HttpStatus.BAD_REQUEST, "객체 변환이 되지 않습니다. 옳은 형식을 보내주세요."),
     INVALID_FIELD(HttpStatus.BAD_REQUEST, "인자 형식이 맞지 않습니다."),
     INVALID_JWT_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 JWT 토큰입니다."),
+    MISMATCH_JWT_USER(HttpStatus.BAD_REQUEST, "jwt 토큰과 요청 유저가 일치하지 않습니다."),
+
+    /* 401 UNAUTHORIZED : 잘못된 요청 */
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "유효한 인증 자격 증명이 없습니다."),
 
     /* 404 NOT_FOUND : Resource 를 찾을 수 없음 */
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 유저 정보를 찾을 수 없습니다"),

--- a/src/main/java/com/hsu/mamomo/service/HeartService.java
+++ b/src/main/java/com/hsu/mamomo/service/HeartService.java
@@ -3,13 +3,16 @@ package com.hsu.mamomo.service;
 import static com.hsu.mamomo.controller.exception.ErrorCode.ALREADY_HEARTED;
 import static com.hsu.mamomo.controller.exception.ErrorCode.CAMPAIGN_NOT_FOUND;
 import static com.hsu.mamomo.controller.exception.ErrorCode.HEART_NOT_FOUND;
+import static com.hsu.mamomo.controller.exception.ErrorCode.INVALID_JWT_TOKEN;
 import static com.hsu.mamomo.controller.exception.ErrorCode.MEMBER_NOT_FOUND;
+import static com.hsu.mamomo.controller.exception.ErrorCode.MISMATCH_JWT_USER;
 
 import com.hsu.mamomo.controller.exception.CustomException;
 import com.hsu.mamomo.domain.Campaign;
 import com.hsu.mamomo.domain.Heart;
 import com.hsu.mamomo.domain.User;
 import com.hsu.mamomo.dto.HeartDto;
+import com.hsu.mamomo.jwt.JwtTokenProvider;
 import com.hsu.mamomo.repository.elastic.CampaignRepository;
 import com.hsu.mamomo.repository.jpa.HeartRepository;
 import com.hsu.mamomo.repository.jpa.UserRepository;
@@ -32,8 +35,11 @@ public class HeartService {
     private final UserRepository userRepository;
     private final CampaignRepository campaignRepository;
     private final RestHighLevelClient elasticsearchClient;
+    private final JwtTokenProvider jwtTokenProvider;
+    private User user;
 
-    public void heart(HeartDto heartDto) throws IOException {
+    public void heart(HeartDto heartDto, String jwtToken) throws IOException {
+        validateToken(heartDto, jwtToken);
 
         // 이미 좋아요 된 캠페인일 경우 409 에러
         if (findHeartWithUserAndCampaignId(heartDto).isPresent()) {
@@ -50,7 +56,9 @@ public class HeartService {
 
     }
 
-    public void unHeart(HeartDto heartDto) throws IOException {
+    public void unHeart(HeartDto heartDto, String jwtToken) throws IOException {
+        validateToken(heartDto, jwtToken);
+
         Optional<Heart> heartOpt = findHeartWithUserAndCampaignId(heartDto);
 
         if (heartOpt.isEmpty()) {
@@ -62,14 +70,29 @@ public class HeartService {
         updateHeartCount(heartDto.getCampaignId(), -1);
     }
 
-    public Optional<Heart> findHeartWithUserAndCampaignId(HeartDto heartDto) {
+    public void validateToken(HeartDto heartDto, String jwtToken) {
+        // 유효한 토큰인지 검증
+        if (!jwtTokenProvider.validateToken(jwtToken)) {
+            throw new CustomException(INVALID_JWT_TOKEN);
+        }
+
+        // 해당 유저 존재하는지 검증
         Optional<User> userOpt = userRepository.findUserById(heartDto.getUserId());
         if (userOpt.isEmpty()) {
             throw new CustomException(MEMBER_NOT_FOUND);
+        } else {
+            user = userOpt.get();
         }
 
+        // 토큰 정보와 요청 userId 정보가 같은지 검증
+        if (!jwtTokenProvider.getUserPk(jwtToken).equals(userOpt.get().getEmail())) {
+            throw new CustomException(MISMATCH_JWT_USER);
+        }
+    }
+
+    public Optional<Heart> findHeartWithUserAndCampaignId(HeartDto heartDto) {
         return heartRepository
-                .findHeartByUserAndCampaignId(userOpt.get(), heartDto.getCampaignId());
+                .findHeartByUserAndCampaignId(user, heartDto.getCampaignId());
     }
 
     public void updateHeartCount(String campaignId, Integer plusOrMinus) throws IOException {


### PR DESCRIPTION
- AUTHORIZATION에 토큰 있어야만, 유효해야만 좋아요/좋아요 취소 가능
- 이때 body의 userID와도 정보가 일치해야함
- 테스트, 문서에도 추가